### PR TITLE
Add tests and extraArgs option

### DIFF
--- a/nixos/modules/services/torrent/qbittorrent.nix
+++ b/nixos/modules/services/torrent/qbittorrent.nix
@@ -75,7 +75,7 @@ in
 
     webuiPort = mkOption {
       default = 8080;
-      type = port;
+      type = nullOr port;
       description = "the port passed to qbittorrent via `--webui-port`";
     };
 
@@ -156,8 +156,8 @@ in
             [
               (getExe cfg.package)
               "--profile=${cfg.profileDir}"
-              "--webui-port=${toString cfg.webuiPort}"
             ]
+            ++ lib.optional (cfg.webuiPort != null) "--webui-port=${toString cfg.webuiPort}"
             ++ lib.optional (cfg.torrentingPort != null) "--torrenting-port=${toString cfg.torrentingPort}"
             ++ cfg.extraArgs
           );
@@ -209,7 +209,8 @@ in
     };
 
     networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall (
-      [ cfg.webuiPort ] ++ lib.optional (cfg.torrentingPort != null) cfg.torrentingPort
+      lib.optional (cfg.webuiPort != null) cfg.webuiPort
+      ++ lib.optional (cfg.torrentingPort != null) cfg.torrentingPort
     );
   };
   meta.maintainers = with maintainers; [ fsnkty ];

--- a/nixos/modules/services/torrent/qbittorrent.nix
+++ b/nixos/modules/services/torrent/qbittorrent.nix
@@ -107,6 +107,17 @@ in
         }
       '';
     };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Extra arguments passed to qbittorrent. See `qbittorrent -h`, or the [source code](https://github.com/qbittorrent/qBittorrent/blob/master/src/app/cmdoptions.cpp), for the available arguments.
+      '';
+      example = [
+        "--confirm-legal-notice"
+      ];
+    };
   };
   config = lib.mkIf cfg.enable {
     systemd = {
@@ -148,6 +159,7 @@ in
               "--webui-port=${toString cfg.webuiPort}"
             ]
             ++ lib.optional (cfg.torrentingPort != null) "--torrenting-port=${toString cfg.torrentingPort}"
+            ++ cfg.extraArgs
           );
           TimeoutStopSec = 1800;
 

--- a/nixos/modules/services/torrent/qbittorrent.nix
+++ b/nixos/modules/services/torrent/qbittorrent.nix
@@ -46,6 +46,7 @@ let
       else
         mkKeyValueDefault { } sep k v;
   };
+  configFile = pkgs.writeText "qBittorrent.conf" (gendeepINI cfg.serverConfig);
 in
 {
   options.services.qbittorrent = {
@@ -134,7 +135,7 @@ in
           "${cfg.profileDir}/qBittorrent/config/qBittorrent.conf"."L+" = lib.mkIf (cfg.serverConfig != null) {
             mode = "1400";
             inherit (cfg) user group;
-            argument = "${pkgs.writeText "qBittorrent.conf" (gendeepINI cfg.serverConfig)}";
+            argument = "${configFile}";
           };
         };
       };
@@ -147,6 +148,7 @@ in
           "nss-lookup.target"
         ];
         wantedBy = [ "multi-user.target" ];
+        restartTriggers = lib.optional (cfg.serverConfig != null) configFile;
 
         serviceConfig = {
           Type = "simple";

--- a/nixos/modules/services/torrent/qbittorrent.nix
+++ b/nixos/modules/services/torrent/qbittorrent.nix
@@ -86,6 +86,7 @@ in
     };
 
     serverConfig = mkOption {
+      default = null;
       type = unspecified;
       description = ''
         Free-form settings mapped to the `qBittorrent.conf` file in the profile.

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -838,6 +838,7 @@ in {
   public-inbox = handleTest ./public-inbox.nix {};
   pufferpanel = handleTest ./pufferpanel.nix {};
   pulseaudio = discoverTests (import ./pulseaudio.nix);
+  qbittorrent = handleTest ./qbittorrent.nix {};
   qboot = handleTestOn ["x86_64-linux" "i686-linux"] ./qboot.nix {};
   qemu-vm-restrictnetwork = handleTest ./qemu-vm-restrictnetwork.nix {};
   qemu-vm-volatile-root = runTest ./qemu-vm-volatile-root.nix;

--- a/nixos/tests/qbittorrent.nix
+++ b/nixos/tests/qbittorrent.nix
@@ -1,184 +1,192 @@
-import ./make-test-python.nix ({pkgs, ...}: {
-  name = "qbittorrent";
+import ./make-test-python.nix (
+  { pkgs, ... }:
+  {
+    name = "qbittorrent";
 
-  meta = with pkgs.lib.maintainers; {maintainers = [fsnkty];};
-
-  nodes = {
-    simple = {
-      services.qbittorrent.enable = true;
-
-      specialisation.portChange.configuration = {
-        services.qbittorrent = {
-          enable = true;
-          webuiPort = 5555;
-          torrentingPort = 44444;
-        };
-      };
-
-      specialisation.openPorts.configuration = {
-        services.qbittorrent = {
-          enable = true;
-          openFirewall = true;
-          webuiPort = 8080;
-          torrentingPort = 55555;
-        };
-      };
-
-      specialisation.serverConfig.configuration = {
-        services.qbittorrent = {
-          enable = true;
-          webuiPort = null;
-          serverConfig.Preferences.WebUI.Port = "8181";
-        };
-      };
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [ fsnkty ];
     };
-    # Seperate vm because it's not possible to reboot into a specialisation with
-    # switch-to-configuration: https://github.com/NixOS/nixpkgs/issues/82851
-    # For one of the test we check if manual changes are overridden during
-    # reboot, therefore it's necessary to reboot into a declarative setup.
-    declarative = {
-      services.qbittorrent = {
-        enable = true;
-        webuiPort = null;
-        serverConfig = {
-          Preferences = {
-            WebUI = {
-              Username = "user";
-              # Default password: adminadmin
-              Password_PBKDF2 = "@ByteArray(6DIf26VOpTCYbgNiO6DAFQ==:e6241eaAWGzRotQZvVA5/up9fj5wwSAThLgXI2lVMsYTu1StUgX9MgmElU3Sa/M8fs+zqwZv9URiUOObjqJGNw==)";
-              Port = "8181";
-            };
+
+    nodes = {
+      simple = {
+        services.qbittorrent.enable = true;
+
+        specialisation.portChange.configuration = {
+          services.qbittorrent = {
+            enable = true;
+            webuiPort = 5555;
+            torrentingPort = 44444;
+          };
+        };
+
+        specialisation.openPorts.configuration = {
+          services.qbittorrent = {
+            enable = true;
+            openFirewall = true;
+            webuiPort = 8080;
+            torrentingPort = 55555;
+          };
+        };
+
+        specialisation.serverConfig.configuration = {
+          services.qbittorrent = {
+            enable = true;
+            webuiPort = null;
+            serverConfig.Preferences.WebUI.Port = "8181";
           };
         };
       };
-
-      specialisation.serverConfigChange.configuration = {
+      # Seperate vm because it's not possible to reboot into a specialisation with
+      # switch-to-configuration: https://github.com/NixOS/nixpkgs/issues/82851
+      # For one of the test we check if manual changes are overridden during
+      # reboot, therefore it's necessary to reboot into a declarative setup.
+      declarative = {
         services.qbittorrent = {
           enable = true;
           webuiPort = null;
-          serverConfig.Preferences.WebUI.Port = "7171";
+          serverConfig = {
+            Preferences = {
+              WebUI = {
+                Username = "user";
+                # Default password: adminadmin
+                Password_PBKDF2 = "@ByteArray(6DIf26VOpTCYbgNiO6DAFQ==:e6241eaAWGzRotQZvVA5/up9fj5wwSAThLgXI2lVMsYTu1StUgX9MgmElU3Sa/M8fs+zqwZv9URiUOObjqJGNw==)";
+                Port = "8181";
+              };
+            };
+          };
+        };
+
+        specialisation.serverConfigChange.configuration = {
+          services.qbittorrent = {
+            enable = true;
+            webuiPort = null;
+            serverConfig.Preferences.WebUI.Port = "7171";
+          };
         };
       };
     };
-  };
 
-  testScript = {nodes, ...}: let
-    simpleSpecPath = "${nodes.simple.system.build.toplevel}/specialisation";
-    declarativeSpecPath = "${nodes.declarative.system.build.toplevel}/specialisation";
-    portChange = "${simpleSpecPath}/portChange";
-    openPorts = "${simpleSpecPath}/openPorts";
-    serverConfig = "${simpleSpecPath}/serverConfig";
-    serverConfigChange = "${declarativeSpecPath}/serverConfigChange";
-  in ''
-    simple.start(allow_reboot=True)
-    declarative.start(allow_reboot=True)
-
-
-    def test_webui(machine, port):
-        machine.wait_for_unit("qbittorrent.service")
-        machine.wait_for_open_port(port)
-        machine.wait_until_succeeds(f"curl --fail http://localhost:{port}")
+    testScript =
+      { nodes, ... }:
+      let
+        simpleSpecPath = "${nodes.simple.system.build.toplevel}/specialisation";
+        declarativeSpecPath = "${nodes.declarative.system.build.toplevel}/specialisation";
+        portChange = "${simpleSpecPath}/portChange";
+        openPorts = "${simpleSpecPath}/openPorts";
+        serverConfig = "${simpleSpecPath}/serverConfig";
+        serverConfigChange = "${declarativeSpecPath}/serverConfigChange";
+      in
+      ''
+        simple.start(allow_reboot=True)
+        declarative.start(allow_reboot=True)
 
 
-    # To simulate an interactive change in the settings
-    def setPreferences_api(machine, port, post_creds, post_data):
-        qb_url = f"http://localhost:{port}"
-        api_url = f"{qb_url}/api/v2"
-        cookie_path = "/tmp/qbittorrent.cookie"
-
-        machine.succeed(
-            f'curl --header "Referer: {qb_url}" \
-            --data "{post_creds}" {api_url}/auth/login \
-            -c {cookie_path}'
-        )
-        machine.succeed(
-            f'curl --header "Referer: {qb_url}" \
-            --data "{post_data}" {api_url}/app/setPreferences \
-            -b {cookie_path}'
-        )
+        def test_webui(machine, port):
+            machine.wait_for_unit("qbittorrent.service")
+            machine.wait_for_open_port(port)
+            machine.wait_until_succeeds(f"curl --fail http://localhost:{port}")
 
 
-    # A randomly generated password is printed in the service log when no
-    # password it set
-    def get_temp_pass(machine):
-        _, password = machine.execute(
-            "journalctl -u qbittorrent.service |\
-            grep 'The WebUI administrator password was not set.' |\
-            awk '{ print $NF }' | tr -d '\n'"
-        )
-        return password
+        # To simulate an interactive change in the settings
+        def setPreferences_api(machine, port, post_creds, post_data):
+            qb_url = f"http://localhost:{port}"
+            api_url = f"{qb_url}/api/v2"
+            cookie_path = "/tmp/qbittorrent.cookie"
 
-
-    # Non declarative tests
-
-    with subtest("webui works with all default settings"):
-        test_webui(simple, 8080)
-
-    with subtest("check if manual changes in settings are saved correctly"):
-        temp_pass = get_temp_pass(simple)
-
-        ## Change some settings
-        api_post = [r"json={\"listen_port\": 33333}", r"json={\"web_ui_port\": 9090}"]
-        for x in api_post:
-            setPreferences_api(
-                machine=simple,
-                port=8080,
-                post_creds=f"username=admin&password={temp_pass}",
-                post_data=x,
+            machine.succeed(
+                f'curl --header "Referer: {qb_url}" \
+                --data "{post_creds}" {api_url}/auth/login \
+                -c {cookie_path}'
+            )
+            machine.succeed(
+                f'curl --header "Referer: {qb_url}" \
+                --data "{post_data}" {api_url}/app/setPreferences \
+                -b {cookie_path}'
             )
 
-        simple.wait_for_open_port(33333)
-        test_webui(simple, 9090)
 
-        ## Test which settings are reset
-        ## As webuiPort is passed as an cli it should reset after reboot
-        ## As torrentingPort is not passed as an cli it should not reset after
-        ## reboot
-        simple.reboot()
-        test_webui(simple, 8080)
-        simple.wait_for_open_port(33333)
-
-    with subtest("ports are changed on config change"):
-        simple.succeed("${portChange}/bin/switch-to-configuration test")
-        test_webui(simple, 5555)
-        simple.wait_for_open_port(44444)
-
-    with subtest("firewall is opened correctly"):
-        simple.succeed("${openPorts}/bin/switch-to-configuration test")
-        test_webui(simple, 8080)
-        declarative.wait_until_succeeds("curl --fail http://simple:8080")
-        declarative.wait_for_open_port(55555, "simple")
-
-    with subtest("switching from simple to declarative works"):
-        simple.succeed("${serverConfig}/bin/switch-to-configuration test")
-        test_webui(simple, 8181)
+        # A randomly generated password is printed in the service log when no
+        # password it set
+        def get_temp_pass(machine):
+            _, password = machine.execute(
+                "journalctl -u qbittorrent.service |\
+                grep 'The WebUI administrator password was not set.' |\
+                awk '{ print $NF }' | tr -d '\n'"
+            )
+            return password
 
 
-    # Declarative tests
+        # Non declarative tests
 
-    with subtest("serverConfig is applied correctly"):
-        test_webui(declarative, 8181)
+        with subtest("webui works with all default settings"):
+            test_webui(simple, 8080)
 
-    with subtest("manual changes are overridden during reboot"):
-        ## Change some settings
-        setPreferences_api(
-            machine=declarative,
-            port=8181, # as set through serverConfig
-            post_creds="username=user&password=adminadmin",
-            post_data=r"json={\"web_ui_port\": 9191}",
-        )
+        with subtest("check if manual changes in settings are saved correctly"):
+            temp_pass = get_temp_pass(simple)
 
-        test_webui(declarative, 9191)
+            ## Change some settings
+            api_post = [r"json={\"listen_port\": 33333}", r"json={\"web_ui_port\": 9090}"]
+            for x in api_post:
+                setPreferences_api(
+                    machine=simple,
+                    port=8080,
+                    post_creds=f"username=admin&password={temp_pass}",
+                    post_data=x,
+                )
 
-        ## Test which settings are reset
-        ## The generated qBittorrent.conf is, apparently, reapplied after reboot.
-        ## Because the port is set in `serverConfig` this overrides the manually
-        ## set port.
-        declarative.reboot()
-        test_webui(declarative, 8181)
+            simple.wait_for_open_port(33333)
+            test_webui(simple, 9090)
 
-    with subtest("changes in serverConfig are applied correctly"):
-        declarative.succeed("${serverConfigChange}/bin/switch-to-configuration test")
-        test_webui(declarative, 7171)
-  '';
-})
+            ## Test which settings are reset
+            ## As webuiPort is passed as an cli it should reset after reboot
+            ## As torrentingPort is not passed as an cli it should not reset after
+            ## reboot
+            simple.reboot()
+            test_webui(simple, 8080)
+            simple.wait_for_open_port(33333)
+
+        with subtest("ports are changed on config change"):
+            simple.succeed("${portChange}/bin/switch-to-configuration test")
+            test_webui(simple, 5555)
+            simple.wait_for_open_port(44444)
+
+        with subtest("firewall is opened correctly"):
+            simple.succeed("${openPorts}/bin/switch-to-configuration test")
+            test_webui(simple, 8080)
+            declarative.wait_until_succeeds("curl --fail http://simple:8080")
+            declarative.wait_for_open_port(55555, "simple")
+
+        with subtest("switching from simple to declarative works"):
+            simple.succeed("${serverConfig}/bin/switch-to-configuration test")
+            test_webui(simple, 8181)
+
+
+        # Declarative tests
+
+        with subtest("serverConfig is applied correctly"):
+            test_webui(declarative, 8181)
+
+        with subtest("manual changes are overridden during reboot"):
+            ## Change some settings
+            setPreferences_api(
+                machine=declarative,
+                port=8181, # as set through serverConfig
+                post_creds="username=user&password=adminadmin",
+                post_data=r"json={\"web_ui_port\": 9191}",
+            )
+
+            test_webui(declarative, 9191)
+
+            ## Test which settings are reset
+            ## The generated qBittorrent.conf is, apparently, reapplied after reboot.
+            ## Because the port is set in `serverConfig` this overrides the manually
+            ## set port.
+            declarative.reboot()
+            test_webui(declarative, 8181)
+
+        with subtest("changes in serverConfig are applied correctly"):
+            declarative.succeed("${serverConfigChange}/bin/switch-to-configuration test")
+            test_webui(declarative, 7171)
+      '';
+  }
+)

--- a/nixos/tests/qbittorrent.nix
+++ b/nixos/tests/qbittorrent.nix
@@ -1,0 +1,40 @@
+import ./make-test-python.nix ({pkgs, ...}: {
+  name = "qbittorrent";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ fsnkty ];
+  };
+
+  nodes = {
+    simple = {
+      services.qbittorrent.enable = true;
+    };
+    declarative = {
+      services.qbittorrent = {
+        enable = true;
+        webuiPort = 8181;
+        openFirewall = true;
+        serverConfig = {
+          LegalNotice.Accepted = true;
+          Preferences = {
+            WebUI.Username = "user";
+            General.Locale = "en";
+          };
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    simple.wait_for_unit("qbittorrent.service")
+    simple.wait_for_open_port(8080)
+    simple.wait_until_succeeds("curl --fail http://localhost:8080")
+
+    declarative.wait_for_unit("qbittorrent.service")
+    declarative.wait_for_open_port(8181)
+    declarative.wait_for_console_text("The WebUI administrator username is: user")
+    declarative.wait_until_succeeds("curl --fail http://localhost:8181")
+    simple.wait_until_succeeds("curl --fail http://declarative:8181")
+  '';
+})

--- a/nixos/tests/qbittorrent.nix
+++ b/nixos/tests/qbittorrent.nix
@@ -1,133 +1,136 @@
-import ./make-test-python.nix ({pkgs, ...}: {
-  name = "qbittorrent";
+import ./make-test-python.nix (
+  { pkgs, ... }:
+  {
+    name = "qbittorrent";
 
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ fsnkty ];
-  };
-
-  nodes = {
-    simple = {
-      services.qbittorrent = {
-        enable = true;
-        openFirewall = true;
-      };
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [ fsnkty ];
     };
-    declarative = {
-      services.qbittorrent = {
-        enable = true;
-        webuiPort = null;
-        serverConfig = {
-          LegalNotice.Accepted = true;
-          Preferences = {
-            WebUI = {
-              Username = "user";
-              # Default password: adminadmin
-              Password_PBKDF2="@ByteArray(6DIf26VOpTCYbgNiO6DAFQ==:e6241eaAWGzRotQZvVA5/up9fj5wwSAThLgXI2lVMsYTu1StUgX9MgmElU3Sa/M8fs+zqwZv9URiUOObjqJGNw==)";
-              Port = "8181";
-            };
-            General.Locale = "en";
-          };
+
+    nodes = {
+      simple = {
+        services.qbittorrent = {
+          enable = true;
+          openFirewall = true;
         };
-        # torrenting-port can also be set through the torrentingPort module option.
-        # We set it this way to make it easy to test extraArgs
-        extraArgs = [ "--torrenting-port=55555" ];
+      };
+      declarative = {
+        services.qbittorrent = {
+          enable = true;
+          webuiPort = null;
+          serverConfig = {
+            LegalNotice.Accepted = true;
+            Preferences = {
+              WebUI = {
+                Username = "user";
+                # Default password: adminadmin
+                Password_PBKDF2 = "@ByteArray(6DIf26VOpTCYbgNiO6DAFQ==:e6241eaAWGzRotQZvVA5/up9fj5wwSAThLgXI2lVMsYTu1StUgX9MgmElU3Sa/M8fs+zqwZv9URiUOObjqJGNw==)";
+                Port = "8181";
+              };
+              General.Locale = "en";
+            };
+          };
+          # torrenting-port can also be set through the torrentingPort module option.
+          # We set it this way to make it easy to test extraArgs
+          extraArgs = [ "--torrenting-port=55555" ];
+        };
       };
     };
-  };
 
-  testScript = ''
-    simple.start(allow_reboot=True)
-    declarative.start(allow_reboot=True)
-
-
-    def test_webui(machine, port):
-        machine.wait_for_unit("qbittorrent.service")
-        machine.wait_for_open_port(port)
-        machine.wait_until_succeeds(f"curl --fail http://localhost:{port}")
+    testScript = ''
+      simple.start(allow_reboot=True)
+      declarative.start(allow_reboot=True)
 
 
-    # To simulate an interactive change in the settings
-    def setPreferences_api(machine, port, post_creds, post_data):
-        qb_url = f"http://localhost:{port}"
-        api_url = f"{qb_url}/api/v2"
-        cookie_path = "/tmp/qbittorrent.cookie"
-
-        machine.succeed(
-            f'curl --header "Referer: {qb_url}" \
-            --data "{post_creds}" {api_url}/auth/login \
-            -c {cookie_path}'
-        )
-        machine.succeed(
-            f'curl --header "Referer: {qb_url}" \
-            --data "{post_data}" {api_url}/app/setPreferences \
-            -b {cookie_path}'
-        )
+      def test_webui(machine, port):
+          machine.wait_for_unit("qbittorrent.service")
+          machine.wait_for_open_port(port)
+          machine.wait_until_succeeds(f"curl --fail http://localhost:{port}")
 
 
-    # A randomly generated password is printed in the service log when no
-    # password it set
-    def get_temp_pass(machine):
-        _, password = machine.execute(
-            "journalctl -u qbittorrent.service |\
-      grep 'The WebUI administrator password was not set.' |\
-      awk '{ print $NF }' | tr -d '\n'"
-        )
-        return password
+      # To simulate an interactive change in the settings
+      def setPreferences_api(machine, port, post_creds, post_data):
+          qb_url = f"http://localhost:{port}"
+          api_url = f"{qb_url}/api/v2"
+          cookie_path = "/tmp/qbittorrent.cookie"
+
+          machine.succeed(
+              f'curl --header "Referer: {qb_url}" \
+              --data "{post_creds}" {api_url}/auth/login \
+              -c {cookie_path}'
+          )
+          machine.succeed(
+              f'curl --header "Referer: {qb_url}" \
+              --data "{post_data}" {api_url}/app/setPreferences \
+              -b {cookie_path}'
+          )
 
 
-    # Test simple VM
-    test_webui(simple, 8080)
-
-    ## Test if firewall is opened correctly
-    declarative.wait_until_succeeds("curl --fail http://simple:8080")
-
-    ## Change some settings
-    simple_pass = get_temp_pass(simple)
-
-    setPreferences_api(
-        machine=simple,
-        port=8080,
-        post_creds=f"username=admin&password={simple_pass}",
-        post_data=r"json={\"listen_port\": 33333}",
-    )
-    setPreferences_api(
-        machine=simple,
-        port=8080,
-        post_creds=f"username=admin&password={simple_pass}",
-        post_data=r"json={\"web_ui_port\": 9090}",
-    )
-
-    simple.wait_for_open_port(33333)
-    test_webui(simple, 9090)
-
-    ## Test which settings are reset
-    ## As webuiPort is passed as an cli it should reset after reboot
-    ## As torrentingPort is not passed as an cli it should not reset after
-    ## reboot
-    simple.reboot()
-    test_webui(simple, 8080)
-    simple.wait_for_open_port(33333)
+      # A randomly generated password is printed in the service log when no
+      # password it set
+      def get_temp_pass(machine):
+          _, password = machine.execute(
+              "journalctl -u qbittorrent.service |\
+        grep 'The WebUI administrator password was not set.' |\
+        awk '{ print $NF }' | tr -d '\n'"
+          )
+          return password
 
 
-    # Test declarative VM
-    test_webui(declarative, 8181)
-    declarative.wait_for_open_port(55555)
+      # Test simple VM
+      test_webui(simple, 8080)
 
-    ## Change some settings
-    setPreferences_api(
-        machine=declarative,
-        port=8181,  # as set through serverConfig
-        post_creds="username=user&password=adminadmin",
-        post_data=r"json={\"web_ui_port\": 9191}",
-    )
+      ## Test if firewall is opened correctly
+      declarative.wait_until_succeeds("curl --fail http://simple:8080")
 
-    test_webui(declarative, 9191)
+      ## Change some settings
+      simple_pass = get_temp_pass(simple)
 
-    ## Test which settings are reset
-    ## The generated qBittorrent.conf is, apparently, reapplied after reboot.
-    ## Because the port is set in `serverConfig` this overrides the manually
-    ## set port.
-    declarative.reboot()
-    test_webui(declarative, 8181)
-  '';
-})
+      setPreferences_api(
+          machine=simple,
+          port=8080,
+          post_creds=f"username=admin&password={simple_pass}",
+          post_data=r"json={\"listen_port\": 33333}",
+      )
+      setPreferences_api(
+          machine=simple,
+          port=8080,
+          post_creds=f"username=admin&password={simple_pass}",
+          post_data=r"json={\"web_ui_port\": 9090}",
+      )
+
+      simple.wait_for_open_port(33333)
+      test_webui(simple, 9090)
+
+      ## Test which settings are reset
+      ## As webuiPort is passed as an cli it should reset after reboot
+      ## As torrentingPort is not passed as an cli it should not reset after
+      ## reboot
+      simple.reboot()
+      test_webui(simple, 8080)
+      simple.wait_for_open_port(33333)
+
+
+      # Test declarative VM
+      test_webui(declarative, 8181)
+      declarative.wait_for_open_port(55555)
+
+      ## Change some settings
+      setPreferences_api(
+          machine=declarative,
+          port=8181,  # as set through serverConfig
+          post_creds="username=user&password=adminadmin",
+          post_data=r"json={\"web_ui_port\": 9191}",
+      )
+
+      test_webui(declarative, 9191)
+
+      ## Test which settings are reset
+      ## The generated qBittorrent.conf is, apparently, reapplied after reboot.
+      ## Because the port is set in `serverConfig` this overrides the manually
+      ## set port.
+      declarative.reboot()
+      test_webui(declarative, 8181)
+    '';
+  }
+)

--- a/nixos/tests/qbittorrent.nix
+++ b/nixos/tests/qbittorrent.nix
@@ -20,6 +20,9 @@ import ./make-test-python.nix ({pkgs, ...}: {
             General.Locale = "en";
           };
         };
+        # torrenting-port can also be set through the torrentingPort module option.
+        # We set it this way to make it easy to test extraArgs
+        extraArgs = [ "--torrenting-port=55555" ];
       };
     };
   };
@@ -33,6 +36,7 @@ import ./make-test-python.nix ({pkgs, ...}: {
 
     declarative.wait_for_unit("qbittorrent.service")
     declarative.wait_for_open_port(8181)
+    declarative.wait_for_open_port(55555)
     declarative.wait_for_console_text("The WebUI administrator username is: user")
     declarative.wait_until_succeeds("curl --fail http://localhost:8181")
     simple.wait_until_succeeds("curl --fail http://declarative:8181")

--- a/nixos/tests/qbittorrent.nix
+++ b/nixos/tests/qbittorrent.nix
@@ -36,7 +36,8 @@ import ./make-test-python.nix ({pkgs, ...}: {
   };
 
   testScript = ''
-    start_all()
+    simple.start(allow_reboot=True)
+    declarative.start(allow_reboot=True)
 
 
     def test_webui(machine, port):
@@ -103,8 +104,7 @@ import ./make-test-python.nix ({pkgs, ...}: {
     ## As webuiPort is passed as an cli it should reset after reboot
     ## As torrentingPort is not passed as an cli it should not reset after
     ## reboot
-    simple.shutdown()
-    simple.start()
+    simple.reboot()
     test_webui(simple, 8080)
     simple.wait_for_open_port(33333)
 
@@ -127,8 +127,7 @@ import ./make-test-python.nix ({pkgs, ...}: {
     ## The generated qBittorrent.conf is, apparently, reapplied after reboot.
     ## Because the port is set in `serverConfig` this overrides the manually
     ## set port.
-    declarative.shutdown()
-    declarative.start()
+    declarative.reboot()
     test_webui(declarative, 8181)
   '';
 })

--- a/nixos/tests/qbittorrent.nix
+++ b/nixos/tests/qbittorrent.nix
@@ -1,136 +1,184 @@
-import ./make-test-python.nix (
-  { pkgs, ... }:
-  {
-    name = "qbittorrent";
+import ./make-test-python.nix ({pkgs, ...}: {
+  name = "qbittorrent";
 
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [ fsnkty ];
-    };
+  meta = with pkgs.lib.maintainers; {maintainers = [fsnkty];};
 
-    nodes = {
-      simple = {
+  nodes = {
+    simple = {
+      services.qbittorrent.enable = true;
+
+      specialisation.portChange.configuration = {
+        services.qbittorrent = {
+          enable = true;
+          webuiPort = 5555;
+          torrentingPort = 44444;
+        };
+      };
+
+      specialisation.openPorts.configuration = {
         services.qbittorrent = {
           enable = true;
           openFirewall = true;
+          webuiPort = 8080;
+          torrentingPort = 55555;
         };
       };
-      declarative = {
+
+      specialisation.serverConfig.configuration = {
         services.qbittorrent = {
           enable = true;
           webuiPort = null;
-          serverConfig = {
-            LegalNotice.Accepted = true;
-            Preferences = {
-              WebUI = {
-                Username = "user";
-                # Default password: adminadmin
-                Password_PBKDF2 = "@ByteArray(6DIf26VOpTCYbgNiO6DAFQ==:e6241eaAWGzRotQZvVA5/up9fj5wwSAThLgXI2lVMsYTu1StUgX9MgmElU3Sa/M8fs+zqwZv9URiUOObjqJGNw==)";
-                Port = "8181";
-              };
-              General.Locale = "en";
-            };
-          };
-          # torrenting-port can also be set through the torrentingPort module option.
-          # We set it this way to make it easy to test extraArgs
-          extraArgs = [ "--torrenting-port=55555" ];
+          serverConfig.Preferences.WebUI.Port = "8181";
         };
       };
     };
+    # Seperate vm because it's not possible to reboot into a specialisation with
+    # switch-to-configuration: https://github.com/NixOS/nixpkgs/issues/82851
+    # For one of the test we check if manual changes are overridden during
+    # reboot, therefore it's necessary to reboot into a declarative setup.
+    declarative = {
+      services.qbittorrent = {
+        enable = true;
+        webuiPort = null;
+        serverConfig = {
+          Preferences = {
+            WebUI = {
+              Username = "user";
+              # Default password: adminadmin
+              Password_PBKDF2 = "@ByteArray(6DIf26VOpTCYbgNiO6DAFQ==:e6241eaAWGzRotQZvVA5/up9fj5wwSAThLgXI2lVMsYTu1StUgX9MgmElU3Sa/M8fs+zqwZv9URiUOObjqJGNw==)";
+              Port = "8181";
+            };
+          };
+        };
+      };
 
-    testScript = ''
-      simple.start(allow_reboot=True)
-      declarative.start(allow_reboot=True)
+      specialisation.serverConfigChange.configuration = {
+        services.qbittorrent = {
+          enable = true;
+          webuiPort = null;
+          serverConfig.Preferences.WebUI.Port = "7171";
+        };
+      };
+    };
+  };
 
-
-      def test_webui(machine, port):
-          machine.wait_for_unit("qbittorrent.service")
-          machine.wait_for_open_port(port)
-          machine.wait_until_succeeds(f"curl --fail http://localhost:{port}")
-
-
-      # To simulate an interactive change in the settings
-      def setPreferences_api(machine, port, post_creds, post_data):
-          qb_url = f"http://localhost:{port}"
-          api_url = f"{qb_url}/api/v2"
-          cookie_path = "/tmp/qbittorrent.cookie"
-
-          machine.succeed(
-              f'curl --header "Referer: {qb_url}" \
-              --data "{post_creds}" {api_url}/auth/login \
-              -c {cookie_path}'
-          )
-          machine.succeed(
-              f'curl --header "Referer: {qb_url}" \
-              --data "{post_data}" {api_url}/app/setPreferences \
-              -b {cookie_path}'
-          )
-
-
-      # A randomly generated password is printed in the service log when no
-      # password it set
-      def get_temp_pass(machine):
-          _, password = machine.execute(
-              "journalctl -u qbittorrent.service |\
-        grep 'The WebUI administrator password was not set.' |\
-        awk '{ print $NF }' | tr -d '\n'"
-          )
-          return password
-
-
-      # Test simple VM
-      test_webui(simple, 8080)
-
-      ## Test if firewall is opened correctly
-      declarative.wait_until_succeeds("curl --fail http://simple:8080")
-
-      ## Change some settings
-      simple_pass = get_temp_pass(simple)
-
-      setPreferences_api(
-          machine=simple,
-          port=8080,
-          post_creds=f"username=admin&password={simple_pass}",
-          post_data=r"json={\"listen_port\": 33333}",
-      )
-      setPreferences_api(
-          machine=simple,
-          port=8080,
-          post_creds=f"username=admin&password={simple_pass}",
-          post_data=r"json={\"web_ui_port\": 9090}",
-      )
-
-      simple.wait_for_open_port(33333)
-      test_webui(simple, 9090)
-
-      ## Test which settings are reset
-      ## As webuiPort is passed as an cli it should reset after reboot
-      ## As torrentingPort is not passed as an cli it should not reset after
-      ## reboot
-      simple.reboot()
-      test_webui(simple, 8080)
-      simple.wait_for_open_port(33333)
+  testScript = {nodes, ...}: let
+    simpleSpecPath = "${nodes.simple.system.build.toplevel}/specialisation";
+    declarativeSpecPath = "${nodes.declarative.system.build.toplevel}/specialisation";
+    portChange = "${simpleSpecPath}/portChange";
+    openPorts = "${simpleSpecPath}/openPorts";
+    serverConfig = "${simpleSpecPath}/serverConfig";
+    serverConfigChange = "${declarativeSpecPath}/serverConfigChange";
+  in ''
+    simple.start(allow_reboot=True)
+    declarative.start(allow_reboot=True)
 
 
-      # Test declarative VM
-      test_webui(declarative, 8181)
-      declarative.wait_for_open_port(55555)
+    def test_webui(machine, port):
+        machine.wait_for_unit("qbittorrent.service")
+        machine.wait_for_open_port(port)
+        machine.wait_until_succeeds(f"curl --fail http://localhost:{port}")
 
-      ## Change some settings
-      setPreferences_api(
-          machine=declarative,
-          port=8181,  # as set through serverConfig
-          post_creds="username=user&password=adminadmin",
-          post_data=r"json={\"web_ui_port\": 9191}",
-      )
 
-      test_webui(declarative, 9191)
+    # To simulate an interactive change in the settings
+    def setPreferences_api(machine, port, post_creds, post_data):
+        qb_url = f"http://localhost:{port}"
+        api_url = f"{qb_url}/api/v2"
+        cookie_path = "/tmp/qbittorrent.cookie"
 
-      ## Test which settings are reset
-      ## The generated qBittorrent.conf is, apparently, reapplied after reboot.
-      ## Because the port is set in `serverConfig` this overrides the manually
-      ## set port.
-      declarative.reboot()
-      test_webui(declarative, 8181)
-    '';
-  }
-)
+        machine.succeed(
+            f'curl --header "Referer: {qb_url}" \
+            --data "{post_creds}" {api_url}/auth/login \
+            -c {cookie_path}'
+        )
+        machine.succeed(
+            f'curl --header "Referer: {qb_url}" \
+            --data "{post_data}" {api_url}/app/setPreferences \
+            -b {cookie_path}'
+        )
+
+
+    # A randomly generated password is printed in the service log when no
+    # password it set
+    def get_temp_pass(machine):
+        _, password = machine.execute(
+            "journalctl -u qbittorrent.service |\
+            grep 'The WebUI administrator password was not set.' |\
+            awk '{ print $NF }' | tr -d '\n'"
+        )
+        return password
+
+
+    # Non declarative tests
+
+    with subtest("webui works with all default settings"):
+        test_webui(simple, 8080)
+
+    with subtest("check if manual changes in settings are saved correctly"):
+        temp_pass = get_temp_pass(simple)
+
+        ## Change some settings
+        api_post = [r"json={\"listen_port\": 33333}", r"json={\"web_ui_port\": 9090}"]
+        for x in api_post:
+            setPreferences_api(
+                machine=simple,
+                port=8080,
+                post_creds=f"username=admin&password={temp_pass}",
+                post_data=x,
+            )
+
+        simple.wait_for_open_port(33333)
+        test_webui(simple, 9090)
+
+        ## Test which settings are reset
+        ## As webuiPort is passed as an cli it should reset after reboot
+        ## As torrentingPort is not passed as an cli it should not reset after
+        ## reboot
+        simple.reboot()
+        test_webui(simple, 8080)
+        simple.wait_for_open_port(33333)
+
+    with subtest("ports are changed on config change"):
+        simple.succeed("${portChange}/bin/switch-to-configuration test")
+        test_webui(simple, 5555)
+        simple.wait_for_open_port(44444)
+
+    with subtest("firewall is opened correctly"):
+        simple.succeed("${openPorts}/bin/switch-to-configuration test")
+        test_webui(simple, 8080)
+        declarative.wait_until_succeeds("curl --fail http://simple:8080")
+        declarative.wait_for_open_port(55555, "simple")
+
+    with subtest("switching from simple to declarative works"):
+        simple.succeed("${serverConfig}/bin/switch-to-configuration test")
+        test_webui(simple, 8181)
+
+
+    # Declarative tests
+
+    with subtest("serverConfig is applied correctly"):
+        test_webui(declarative, 8181)
+
+    with subtest("manual changes are overridden during reboot"):
+        ## Change some settings
+        setPreferences_api(
+            machine=declarative,
+            port=8181, # as set through serverConfig
+            post_creds="username=user&password=adminadmin",
+            post_data=r"json={\"web_ui_port\": 9191}",
+        )
+
+        test_webui(declarative, 9191)
+
+        ## Test which settings are reset
+        ## The generated qBittorrent.conf is, apparently, reapplied after reboot.
+        ## Because the port is set in `serverConfig` this overrides the manually
+        ## set port.
+        declarative.reboot()
+        test_webui(declarative, 8181)
+
+    with subtest("changes in serverConfig are applied correctly"):
+        declarative.succeed("${serverConfigChange}/bin/switch-to-configuration test")
+        test_webui(declarative, 7171)
+  '';
+})

--- a/nixos/tests/qbittorrent.nix
+++ b/nixos/tests/qbittorrent.nix
@@ -1,22 +1,30 @@
 import ./make-test-python.nix ({pkgs, ...}: {
   name = "qbittorrent";
+
   meta = with pkgs.lib.maintainers; {
     maintainers = [ fsnkty ];
   };
 
   nodes = {
     simple = {
-      services.qbittorrent.enable = true;
+      services.qbittorrent = {
+        enable = true;
+        openFirewall = true;
+      };
     };
     declarative = {
       services.qbittorrent = {
         enable = true;
-        webuiPort = 8181;
-        openFirewall = true;
+        webuiPort = null;
         serverConfig = {
           LegalNotice.Accepted = true;
           Preferences = {
-            WebUI.Username = "user";
+            WebUI = {
+              Username = "user";
+              # Default password: adminadmin
+              Password_PBKDF2="@ByteArray(6DIf26VOpTCYbgNiO6DAFQ==:e6241eaAWGzRotQZvVA5/up9fj5wwSAThLgXI2lVMsYTu1StUgX9MgmElU3Sa/M8fs+zqwZv9URiUOObjqJGNw==)";
+              Port = "8181";
+            };
             General.Locale = "en";
           };
         };
@@ -30,15 +38,97 @@ import ./make-test-python.nix ({pkgs, ...}: {
   testScript = ''
     start_all()
 
-    simple.wait_for_unit("qbittorrent.service")
-    simple.wait_for_open_port(8080)
-    simple.wait_until_succeeds("curl --fail http://localhost:8080")
 
-    declarative.wait_for_unit("qbittorrent.service")
-    declarative.wait_for_open_port(8181)
+    def test_webui(machine, port):
+        machine.wait_for_unit("qbittorrent.service")
+        machine.wait_for_open_port(port)
+        machine.wait_until_succeeds(f"curl --fail http://localhost:{port}")
+
+
+    # To simulate an interactive change in the settings
+    def setPreferences_api(machine, port, post_creds, post_data):
+        qb_url = f"http://localhost:{port}"
+        api_url = f"{qb_url}/api/v2"
+        cookie_path = "/tmp/qbittorrent.cookie"
+
+        machine.succeed(
+            f'curl --header "Referer: {qb_url}" \
+            --data "{post_creds}" {api_url}/auth/login \
+            -c {cookie_path}'
+        )
+        machine.succeed(
+            f'curl --header "Referer: {qb_url}" \
+            --data "{post_data}" {api_url}/app/setPreferences \
+            -b {cookie_path}'
+        )
+
+
+    # A randomly generated password is printed in the service log when no
+    # password it set
+    def get_temp_pass(machine):
+        _, password = machine.execute(
+            "journalctl -u qbittorrent.service |\
+      grep 'The WebUI administrator password was not set.' |\
+      awk '{ print $NF }' | tr -d '\n'"
+        )
+        return password
+
+
+    # Test simple VM
+    test_webui(simple, 8080)
+
+    ## Test if firewall is opened correctly
+    declarative.wait_until_succeeds("curl --fail http://simple:8080")
+
+    ## Change some settings
+    simple_pass = get_temp_pass(simple)
+
+    setPreferences_api(
+        machine=simple,
+        port=8080,
+        post_creds=f"username=admin&password={simple_pass}",
+        post_data=r"json={\"listen_port\": 33333}",
+    )
+    setPreferences_api(
+        machine=simple,
+        port=8080,
+        post_creds=f"username=admin&password={simple_pass}",
+        post_data=r"json={\"web_ui_port\": 9090}",
+    )
+
+    simple.wait_for_open_port(33333)
+    test_webui(simple, 9090)
+
+    ## Test which settings are reset
+    ## As webuiPort is passed as an cli it should reset after reboot
+    ## As torrentingPort is not passed as an cli it should not reset after
+    ## reboot
+    simple.shutdown()
+    simple.start()
+    test_webui(simple, 8080)
+    simple.wait_for_open_port(33333)
+
+
+    # Test declarative VM
+    test_webui(declarative, 8181)
     declarative.wait_for_open_port(55555)
-    declarative.wait_for_console_text("The WebUI administrator username is: user")
-    declarative.wait_until_succeeds("curl --fail http://localhost:8181")
-    simple.wait_until_succeeds("curl --fail http://declarative:8181")
+
+    ## Change some settings
+    setPreferences_api(
+        machine=declarative,
+        port=8181,  # as set through serverConfig
+        post_creds="username=user&password=adminadmin",
+        post_data=r"json={\"web_ui_port\": 9191}",
+    )
+
+    test_webui(declarative, 9191)
+
+    ## Test which settings are reset
+    ## The generated qBittorrent.conf is, apparently, reapplied after reboot.
+    ## Because the port is set in `serverConfig` this overrides the manually
+    ## set port.
+    declarative.shutdown()
+    declarative.start()
+    test_webui(declarative, 8181)
   '';
 })


### PR DESCRIPTION
Hi, 

I made an initial testing setup for the qbittorrent module. Mainly inspired by the tests of the deluge module and some other simple webservices modules. The tests are pretty simple at the moment. If you have any other ideas or edge cases you'd like to test let me know.

While testing I found that there was no default value for `serverConfig`. That's now fixed.

Thanks!